### PR TITLE
I've fixed an issue to prevent an unwanted standalone chart window fr…

### DIFF
--- a/stock_charts_refactored/direct_chart_fix.py
+++ b/stock_charts_refactored/direct_chart_fix.py
@@ -8,7 +8,7 @@ import types
 import os
 import tkinter as tk
 from tkinter import ttk
-import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import pandas as pd
 import pytz
@@ -189,7 +189,8 @@ def apply_direct_chart_fix(app):
                     plot_df = df.copy()
                 
                 # Create figure and axes before checking data
-                fig, ax1 = plt.subplots(figsize=(10, 6))
+                fig = Figure(figsize=(10, 6), dpi=100)
+                ax1 = fig.add_subplot(111)
                 
                 # Check if we have data to plot
                 if plot_df.empty:


### PR DESCRIPTION
…om appearing. Here is a summary of my changes:

- I fixed a bug where clicking a ticker in the "Individual Chart" tab would open an unwanted, standalone matplotlib window.
- I found the root cause was the use of `plt.subplots()` in the `direct_chart_fix.py` patch, which can automatically display a figure depending on the matplotlib backend.
- My fix replaces `plt.subplots()` with the explicit creation of a `matplotlib.figure.Figure` object. This ensures the figure is only rendered on the intended Tkinter canvas.