### PR TITLE
I've fixed the issue where the seasonality chart was crashing when yo…

### DIFF
--- a/stock_charts_refactored/gui.py
+++ b/stock_charts_refactored/gui.py
@@ -1375,7 +1375,7 @@ class StockDataGUI:
                     self._compare_percentage_performance()
                 elif self.active_tab == "seasonality" and selected_tickers:
                     # If seasonality tab is active and a ticker is selected, update seasonality chart
-                    self._generate_seasonality_chart(selected_tickers[0])
+                    self._generate_seasonality_chart(selected_tickers[0], is_new_ticker=True)
                 elif self.active_tab == "individual" and selected_tickers:
                     # If individual tab is active and a ticker is selected, update individual chart
                     self._display_chart(selected_tickers[0])


### PR DESCRIPTION
…u selected a new ticker.

The problem was a `KeyError` that happened because the `_on_watch_ticker_selected` function wasn't letting the `_generate_seasonality_chart` function know that a new ticker had been chosen.

To fix this, I've modified the code to pass `is_new_ticker=True` when `_generate_seasonality_chart` is called from `_on_watch_ticker_selected`. This makes sure the year-selection data is reset correctly for the new ticker, which stops the crash.

As a quick note, I wasn't able to test the GUI from my end since I don't have a display. You might want to confirm everything looks good on your side.