### PR TITLE
Fix: Timeframe charts not displaying data

### DIFF
--- a/stock_charts_refactored/data_manager.py
+++ b/stock_charts_refactored/data_manager.py
@@ -889,22 +889,22 @@ class StockDataManager:
 
             # Apply date range filtering if specified
             if self.start_date:
-                # Convert to pandas Timestamp without timezone for consistent comparison
-                start_date = pd.Timestamp(self.start_date).tz_localize(None)
+                # Convert start_date to a timezone-aware timestamp (UTC)
+                start_date = pd.to_datetime(self.start_date, utc=True)
                 # Log the date range before filtering
-                logging.info(f"Applying start date filter: {self.start_date}, data range: {daily_data.index.min()} to {daily_data.index.max()}")
-                # Convert index to same timezone format for comparison
-                daily_data = daily_data[daily_data.index.tz_localize(None) >= start_date]
+                logging.info(f"Applying start date filter: {start_date}, data range: {daily_data.index.min()} to {daily_data.index.max()}")
+                # Filter data (index is already UTC-aware)
+                daily_data = daily_data[daily_data.index >= start_date]
                 # Log the data range after filtering
                 logging.info(f"After start date filter: data range: {daily_data.index.min()} to {daily_data.index.max()}, rows: {len(daily_data)}")
 
             if self.end_date:
-                # Convert to pandas Timestamp without timezone for consistent comparison
-                end_date = pd.Timestamp(self.end_date).tz_localize(None)
+                # Convert end_date to a timezone-aware timestamp (UTC)
+                end_date = pd.to_datetime(self.end_date, utc=True)
                 # Log the date range before filtering
-                logging.info(f"Applying end date filter: {self.end_date}, data range: {daily_data.index.min()} to {daily_data.index.max()}")
-                # Convert index to same timezone format for comparison
-                daily_data = daily_data[daily_data.index.tz_localize(None) <= end_date]
+                logging.info(f"Applying end date filter: {end_date}, data range: {daily_data.index.min()} to {daily_data.index.max()}")
+                # Filter data (index is already UTC-aware)
+                daily_data = daily_data[daily_data.index <= end_date]
                 # Log the data range after filtering
                 logging.info(f"After end date filter: data range: {daily_data.index.min()} to {daily_data.index.max()}, rows: {len(daily_data)}")
 


### PR DESCRIPTION
The timeframe charts (daily/weekly/monthly) were not displaying data when a date range was applied. This was due to an issue with timezone handling in the date filtering logic.

The `visualize_daily_vs_weekly` function in `data_manager.py` was converting the timezone-aware index of the data to a timezone-naive one before comparing it with the start and end dates. This resulted in the data being filtered incorrectly, leading to an empty dataframe being plotted.

The fix involves changing the date filtering logic to handle timezones correctly. Instead of making the index naive, the start and end dates are now converted to UTC before comparison, ensuring that the comparison is done between two timezone-aware datetime objects.