### PR TITLE
Fix: Timeframe chart not visible due to incorrect tab selection

### DIFF
--- a/stock_charts_refactored/gui.py
+++ b/stock_charts_refactored/gui.py
@@ -1048,6 +1048,8 @@ class StockDataGUI:
 
                 # Display the chart in the GUI
                 if os.path.exists(chart_path):
+                    # Switch to the individual chart tab before displaying
+                    self.chart_notebook.select(self.individual_chart_frame)
                     self._display_chart(chart_path)
                 else:
                     messagebox.showerror("Error", f"Chart file not found for {ticker}")


### PR DESCRIPTION
When the "Visualize Daily/Weekly/Monthly" button was clicked, the generated timeframe chart was not visible in the GUI. This was because the application did not automatically switch to the tab where the chart was being displayed.

This commit fixes the issue by explicitly selecting the "Individual Chart" tab before the chart is rendered. The `_visualize_all_timeframes` method in `gui.py` now calls `self.chart_notebook.select(self.individual_chart_frame)` to ensure that the tab containing the chart is brought to the front.

This should resolve the issue of the timeframe charts not being visible in the GUI.