### PR TITLE
Fix: NameError in emergency_display_chart

### DIFF
--- a/stock_charts_refactored/emergency_fix.py
+++ b/stock_charts_refactored/emergency_fix.py
@@ -2,7 +2,7 @@
 Emergency fix for the persistent dtype comparison error in Plotly chart creation.
 This module provides a direct monkey patch for the specific error location.
 """
-
+import os
 import logging
 import types
 import pandas as pd
@@ -134,5 +134,3 @@ def apply_emergency_fix(app):
     app._display_chart = types.MethodType(emergency_display_chart, app)
     logging.info("Applied emergency fix for dtype comparison error")
 
-# Add missing import
-import os


### PR DESCRIPTION
A `NameError` was being raised in the `emergency_display_chart` function in `emergency_fix.py`. This was because the `os` module was being used without being imported at the top level of the file.

This commit fixes the issue by moving the `import os` statement to the top of the file, ensuring that the `os` module is available throughout the file's scope. The redundant `import os` at the end of the file has also been removed.

This resolves the `cannot access local variable 'os' where it is not associated with a value` error.