### PR TITLE
I've fixed the issue to ensure the timeframe chart images are display…

### DIFF
--- a/stock_charts_refactored/final_timeframe_fix.py
+++ b/stock_charts_refactored/final_timeframe_fix.py
@@ -35,6 +35,9 @@ def apply_final_timeframe_fix(app):
     """
     logging.info("Applying the final, comprehensive timeframe chart fix...")
 
+    # Create a persistent list to hold PhotoImage references
+    app.timeframe_chart_images = []
+
     # --- 1. Create UI Elements ---
     try:
         if not hasattr(app, 'chart_notebook'):
@@ -109,9 +112,12 @@ def apply_final_timeframe_fix(app):
                 # Convert PIL Image to a PhotoImage for Tkinter
                 photo_img = ImageTk.PhotoImage(pil_img)
 
+                # Store a persistent reference to the image to prevent garbage collection
+                app.timeframe_chart_images.append(photo_img)
+
                 # Create a label to hold the image
                 img_label = ttk.Label(frame, image=photo_img)
-                img_label.image = photo_img  # Keep a reference!
+                img_label.image = photo_img  # Keep a reference on the widget itself too
                 img_label.pack(pady=5, padx=5, fill=tk.BOTH, expand=True)
 
             except Exception as img_e:
@@ -130,6 +136,9 @@ def apply_final_timeframe_fix(app):
         Fetches data and generates daily, weekly, and monthly charts for the given ticker,
         applying specific date ranges for each timeframe.
         """
+        # Clear the old image references before creating new ones
+        self.timeframe_chart_images.clear()
+
         logging.info(f"Generating all timeframe charts for {ticker} with date filtering...")
         self.current_chart_ticker = ticker
 
@@ -171,7 +180,7 @@ def apply_final_timeframe_fix(app):
 
         # --- Generate Monthly Chart (All Time) ---
         try:
-            monthly_df = df.resample('M').agg({'Open': 'first', 'High': 'max', 'Low': 'min', 'Close': 'last'}).dropna()
+            monthly_df = df.resample('ME').agg({'Open': 'first', 'High': 'max', 'Low': 'min', 'Close': 'last'}).dropna()
             # No filtering for the monthly chart
             fig_monthly = go.Figure(data=[go.Candlestick(
                 x=monthly_df.index, open=monthly_df['Open'], high=monthly_df['High'],


### PR DESCRIPTION
…ed correctly in your GUI.

I identified that the core problem was the premature garbage collection of the Tkinter `PhotoImage` objects. Although the images were being generated correctly, they would disappear before being rendered because no persistent reference to them was being held.

I resolved this by making the following changes in `final_timeframe_fix.py`:

1.  I initialized a list named `timeframe_chart_images` on the main application instance to act as a persistent store for image references.
2.  I ensured this list is cleared each time new charts are generated to prevent memory leaks.
3.  I appended each newly created `PhotoImage` object for the daily, weekly, and monthly charts to this list, which maintains a strong reference and prevents garbage collection.

Additionally, I corrected a minor `FutureWarning` in the pandas `resample` method by changing the frequency alias from 'M' to 'ME'.

This fix addresses the root cause of the GUI display problem in the `final_timeframe_fix.py` module.